### PR TITLE
script to deploy on all contract networks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,11 @@ yarn global add @graphprotocol/graph-cli
 ```
 
 ```sh
-graph codegen
+yarn install
 ```
 
 ```sh
-graph build
-```
-
-```sh
-graph auth  --studio <deploy key>
-```
-
-```sh
-graph deploy  --studio <subgraph slug>
+yarn network-deploy
 ```
 
 ## Contracts & Deployed Apps
@@ -32,4 +24,10 @@ graph deploy  --studio <subgraph slug>
 | [mainnet](https://edition-drop.vercel.app/?network=1) | [0x91A8713155758d410DFAc33a63E193AE3E89F909](https://etherscan.io/address/0x91A8713155758d410DFAc33a63E193AE3E89F909) |
 | [rinkeby](https://edition-drop.vercel.app/?network=4) | [0x85FaDB8Debc0CED38d0647329fC09143d01Af660](https://rinkeby.etherscan.io/address/0x85FaDB8Debc0CED38d0647329fC09143d01Af660) |
 | [polygon](https://edition-drop.vercel.app/?network=137) | [0x4500590AfC7f12575d613457aF01F06b1eEE57a3](https://polygonscan.com/address/0x4500590AfC7f12575d613457aF01F06b1eEE57a3) |
-| [polygon mumbai](https://edition-drop.vercel.app/?network=80001)) | [0x773E5B82179E6CE1CdF8c5C0d736e797b3ceDDDC](https://mumbai.polygonscan.com/address/0x773E5B82179E6CE1CdF8c5C0d736e797b3ceDDDC) |
+| [polygon mumbai](https://edition-drop.vercel.app/?network=80001) | [0x773E5B82179E6CE1CdF8c5C0d736e797b3ceDDDC](https://mumbai.polygonscan.com/address/0x773E5B82179E6CE1CdF8c5C0d736e797b3ceDDDC) |
+
+## The Graph
+
+- [studio](https://thegraph.com/studio/) | [docs](https://thegraph.com/docs/en/studio/subgraph-studio)
+- [hosted service](https://thegraph.com/hosted-service/dashboard) | [docs](https://thegraph.com/docs/en/hosted-service/what-is-hosted-service)
+- [graph-cli github](https://github.com/graphprotocol/graph-cli)

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -1,0 +1,5 @@
+{
+    "network": "mainnet",
+    "address": "0x91A8713155758d410DFAc33a63E193AE3E89F909",
+    "startBlock": "13443230"
+}

--- a/config/polygon-mumbai.json
+++ b/config/polygon-mumbai.json
@@ -1,0 +1,5 @@
+{
+    "network": "mumbai",
+    "address": "0x773E5B82179E6CE1CdF8c5C0d736e797b3ceDDDC",
+    "startBlock": "22867754"
+}

--- a/config/polygon.json
+++ b/config/polygon.json
@@ -1,0 +1,5 @@
+{
+    "network": "matic",
+    "address": "0x4500590AfC7f12575d613457aF01F06b1eEE57a3",
+    "startBlock": "22719412"
+}

--- a/config/rinkeby.json
+++ b/config/rinkeby.json
@@ -1,0 +1,5 @@
+{
+    "network": "rinkeby",
+    "address": "0x85FaDB8Debc0CED38d0647329fC09143d01Af660",
+    "startBlock": "9488019"
+}

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+select result in mainnet polygon polygon-mumbai rinkeby
+do  
+   if [ $result == "mainnet" ] || [ $result == "rinkeby" ] || [ $result == "polygon" ] || [ $result == "polygon-mumbai" ]; 
+   then
+      break;
+   else
+      echo "Incorrect, please try again: "
+   fi
+done
+
+mustache config/$result.json subgraph.template.yaml > subgraph.yaml
+
+echo "configured for $result"
+
+graph codegen && graph build
+
+echo "wooohooo regen & built!"
+
+if [ $result == "mainnet" ] || [ $result == "rinkeby" ]; 
+then
+   # subgraph studio
+   graph deploy --studio nft-editions-$result
+else 
+   # hosted services (deprecating once fully ported to studio)
+   read -p 'github username: ' uservar
+   read -p 'access token: ' accessToken
+   
+   graph auth --product hosted-service $accessToken
+   graph deploy --product hosted-service $uservar/nft-editions-$result
+fi

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "create-local": "graph create --node http://localhost:8020/ iainnash/nft-editions-subgraph-polygon",
     "remove-local": "graph remove --node http://localhost:8020/ iainnash/nft-editions-subgraph-polygon",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 iainnash/nft-editions-subgraph-polygon",
-    "deploy-mainnet": "graph deploy --studio nft-editions"
+    "network-deploy": "chmod u+x deploy.sh; ./deploy.sh"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.25.1",
-    "@graphprotocol/graph-ts": "0.24.1"
+    "@graphprotocol/graph-ts": "0.24.1",
+    "mustache": "^4.2.0"
   }
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -1,0 +1,45 @@
+specVersion: 0.0.2
+schema:
+  file: ./schema.graphql
+dataSources:
+  - kind: ethereum
+    name: SingleEditionMintableCreator
+    network: {{network}}
+    source:
+      address: "{{address}}"
+      abi: SingleEditionMintableCreator
+      startBlock: {{startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      language: wasm/assemblyscript
+      entities:
+        - CreatedEdition
+      abis:
+        - name: SingleEditionMintableCreator
+          file: ./abis/SingleEditionMintableCreator.json
+      eventHandlers:
+        - event: CreatedEdition(indexed uint256,indexed address,uint256,address)
+          handler: handleCreatedEdition
+      file: ./src/mapping.ts
+templates:
+  - name: NFTEdition
+    kind: ethereum/contract
+    network: {{network}}
+    source:
+      abi: NFTEdition
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.5
+      entities:
+        - PriceChanged
+      language: wasm/assemblyscript
+      file: ./src/mapping.ts
+      abis:
+        - name: NFTEdition
+          file: ./abis/NFTEdition.json
+      eventHandlers:
+        - event: PriceChanged(uint256)
+          handler: handleEditionPriceChanged
+        - event: OwnershipTransferred(indexed address,indexed address)
+          handler: handleInitEdition

--- a/yarn.lock
+++ b/yarn.lock
@@ -1110,6 +1110,18 @@ graphql@^15.5.0:
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.8.0.tgz#33410e96b012fa3bdb1091cc99a94769db212b38"
   integrity sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==
 
+handlebars@^4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
 har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
@@ -2020,6 +2032,11 @@ murmurhash3js@^3.0.1:
   resolved "https://registry.yarnpkg.com/murmurhash3js/-/murmurhash3js-3.0.1.tgz#3e983e5b47c2a06f43a713174e7e435ca044b998"
   integrity sha1-Ppg+W0fCoG9DpxMXTn5DXKBEuZg=
 
+mustache@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/mustache/-/mustache-4.2.0.tgz#e5892324d60a12ec9c2a73359edca52972bf6f64"
+  integrity sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==
+
 mute-stream@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
@@ -2038,6 +2055,11 @@ nan@^2.14.0, nan@^2.14.2:
     minimist "^1.2.0"
     split2 "^3.1.0"
     through2 "^3.0.0"
+
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 node-fetch@^2.3.0:
   version "2.6.6"
@@ -2499,6 +2521,11 @@ signed-varint@^2.0.1:
   dependencies:
     varint "~5.0.0"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 split-ca@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split-ca/-/split-ca-1.0.1.tgz#6c83aff3692fa61256e0cd197e05e9de157691a6"
@@ -2724,6 +2751,11 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+uglify-js@^3.1.4:
+  version "3.15.2"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.15.2.tgz#1ed2c976f448063b1f87adb68c741be79959f951"
+  integrity sha512-peeoTk3hSwYdoc9nrdiEJk+gx1ALCtTjdYuKSXMTDqq7n1W7dHPqWDdSi+BPL0ni2YMeHD7hKUSdbj3TZauY2A==
+
 unique-by@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unique-by/-/unique-by-1.0.0.tgz#5220c86ba7bc572fb713ad74651470cb644212bd"
@@ -2804,6 +2836,11 @@ which@2.0.2, which@^2.0.0, which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
 wordwrap@~0.0.2:
   version "0.0.3"


### PR DESCRIPTION
bored & wanted to learn bash

created the `nft-editions` subgraph on [studio](https://thegraph.com/studio/) or [hosted service](https://thegraph.com/hosted-service/dashboard) suffixed by its network

`yarn network-deploy`: codegen, build, & deploy for a network 

- mainnet & rinkeby: studio
- matic & mumbai: hosted service (not yet supported on studio)